### PR TITLE
Solved a few issues with Mathjax.

### DIFF
--- a/basic-probability/index.html
+++ b/basic-probability/index.html
@@ -27,7 +27,7 @@
     <link href="./basic-probability.css" rel="stylesheet">
 
     <!-- MathJax JS -->
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
 
 </head>
 

--- a/compound-probability/index.html
+++ b/compound-probability/index.html
@@ -33,7 +33,7 @@
     <link href="./compound-probability.css" rel="stylesheet">
 
     <!-- MathJax JS -->
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
 
 </head>
 

--- a/distributions/index.html
+++ b/distributions/index.html
@@ -30,7 +30,7 @@
     <link href="./distributions.css" rel="stylesheet">
 
     <!-- MathJax JS -->
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
 
 </head>
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <link href="css/font-awesome/css/font-awesome.min.css" rel="stylesheet">
 
     <!-- MathJax JS -->
-    <!--<script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>-->
+    <!--<script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>-->
 
 </head>
 

--- a/regression/index.html
+++ b/regression/index.html
@@ -27,7 +27,7 @@
     <link href="./regression.css" rel="stylesheet">
 
     <!-- MathJax JS -->
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
 
 </head>
 

--- a/statistical-inference/index.html
+++ b/statistical-inference/index.html
@@ -30,7 +30,7 @@
     <link href="./statistical-inference.css" rel="stylesheet">
 
     <!-- MathJax JS -->
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
 
 </head>
 


### PR DESCRIPTION
Updated the link to a new CDN. See https://www.mathjax.org/cdn-shutting-down/.

By doing this, also solved a bug in which opening the website via HTTPS generated a
mixed content error.

The new link has a fixed version, which is considered a best practice to
avoid unexpected changes.