### PR TITLE
Fixed "set identities" hyperlink

### DIFF
--- a/compound-probability/index.html
+++ b/compound-probability/index.html
@@ -113,7 +113,7 @@
                         </div>
                     </div>
                     <p class='text-center' id='invalidSet'></p>
-                    <p>You may wish to use the visualization to verify some of the following <a href='https://cs.brown.edu/courses/cs022/static/files/documents/sets.pdf'>set identities</a>.</p>
+                    <p>You may wish to use the visualization to verify some of the following <a href='https://brown-cs22.github.io/resources/math-resources/sets.pdf'>set identities</a>.</p>
                 </div>
             </div>
             <div id="section2">


### PR DESCRIPTION
Previously would lead to a page with a 404 error, now leads to the proper Brown sets identities link from CS022.

I know this project is no longer maintained, but it was really helpful for me so I thought I'd help out on the off-chance this would be merged.
