### PR TITLE
Fix incorrect page redirect

### DIFF
--- a/probability-distributions/cn.html
+++ b/probability-distributions/cn.html
@@ -553,7 +553,7 @@
                 </ul>
             </div>
             <div class="modal-visualization">
-                <div id="bp" class="current">
+                <div id="bp">
                     <div class="nav-unit-wrapper-s tile1">
                         <img src="../img/tiles/1-1.png" class="nav-unit-tile-s">
                         <span class="nav-unit-title-s"> 随机事件 </span>


### PR DESCRIPTION
For the Chinese version, page "Probability Distributions" (概率分布) cannot redirect to page "Basic Probability" (基础概率论).